### PR TITLE
disable touch events

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
     "angular-cesium": "^0.0.25",
     "apollo-angular": "^0.13.0",
     "apollo-client": "^1.9.1",
-    "cesium": "^1.37.0",
+    "cesium": "^1.38.0",
     "core-js": "^2.4.1",
     "graphql-code-generator": "^0.8.10",
     "graphql-tag": "^2.4.2",

--- a/packages/client/src/index.html
+++ b/packages/client/src/index.html
@@ -1,6 +1,9 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <script>
+    navigator.pointerEnabled = false;
+  </script>
   <meta charset="utf-8">
   <title>CesiumFps</title>
   <base href="/">


### PR DESCRIPTION
@tomermoshe 
cesium does setPointerCaputre() on touch event registration.
setPointerCaputre causes an error with requestPointerLock. so I disabled touch events. what do you think?